### PR TITLE
Fix backend module

### DIFF
--- a/Classes/Controller/AjaxController.php
+++ b/Classes/Controller/AjaxController.php
@@ -216,7 +216,7 @@ class AjaxController
                 $this->parameter['session'],
                 Session::class
             );
-        $session->setPid($request->getParsedBody()['id']);
+        $session->setPid(intval($request->getParsedBody()['id']));
         return $session;
     }
 

--- a/Classes/Domain/Model/Session.php
+++ b/Classes/Domain/Model/Session.php
@@ -135,6 +135,7 @@ class Session extends AbstractSlugEntity
         $this->speakers = GeneralUtility::makeInstance(ObjectStorage::class);
         $this->documents = GeneralUtility::makeInstance(ObjectStorage::class);
         $this->tags = GeneralUtility::makeInstance(ObjectStorage::class);
+        $this->links = GeneralUtility::makeInstance(ObjectStorage::class);
     }
 
     /**


### PR DESCRIPTION
For now it is not possible to create sessions in the backend module due to 2 errors:
There is a type mismatch when setting the pid and also a missing initalization within the session domain model.