### PR TITLE
Fix broken adding sessions to sessionplan in backend

### DIFF
--- a/Classes/Controller/AjaxController.php
+++ b/Classes/Controller/AjaxController.php
@@ -216,7 +216,7 @@ class AjaxController
                 $this->parameter['session'],
                 Session::class
             );
-        $session->setPid($request->getParsedBody()['id']);
+        $session->setPid(intval ($request->getParsedBody()['id']));
         return $session;
     }
 

--- a/Classes/Domain/Model/Session.php
+++ b/Classes/Domain/Model/Session.php
@@ -128,13 +128,14 @@ class Session extends AbstractSlugEntity
      * @var \TYPO3\CMS\Extbase\Persistence\ObjectStorage<\Evoweb\Sessionplaner\Domain\Model\Link>
      * @TYPO3\CMS\Extbase\Annotation\ORM\Lazy
      */
-    protected $links = null;
+    protected ObjectStorage $links;
 
     public function initializeObject()
     {
         $this->speakers = GeneralUtility::makeInstance(ObjectStorage::class);
         $this->documents = GeneralUtility::makeInstance(ObjectStorage::class);
         $this->tags = GeneralUtility::makeInstance(ObjectStorage::class);
+        $this->links = new ObjectStorage();
     }
 
     /**

--- a/Classes/Enum/SessionLevelEnum.php
+++ b/Classes/Enum/SessionLevelEnum.php
@@ -20,6 +20,7 @@ class SessionLevelEnum
     public const OPTION_BEGINNER = 1;
     public const OPTION_ADVANCED = 2;
     public const OPTION_PRO = 3;
+    public const OPTION_ALL = 4;
 
     protected static $optionLabel = [
         self::OPTION_BEGINNER =>
@@ -27,7 +28,9 @@ class SessionLevelEnum
         self::OPTION_ADVANCED =>
             'LLL:EXT:sessionplaner/Resources/Private/Language/locallang.xlf:option.sessionlevel.advanced',
         self::OPTION_PRO =>
-            'LLL:EXT:sessionplaner/Resources/Private/Language/locallang.xlf:option.sessionlevel.pro'
+	'LLL:EXT:sessionplaner/Resources/Private/Language/locallang.xlf:option.sessionlevel.pro',
+        self::OPTION_ALL =>
+            'LLL:EXT:sessionplaner/Resources/Private/Language/locallang.xlf:option.sessionlevel.all'
     ];
 
     public static function getLabel(int $option): string
@@ -64,7 +67,8 @@ class SessionLevelEnum
         return [
             self::OPTION_BEGINNER,
             self::OPTION_ADVANCED,
-            self::OPTION_PRO
+	        self::OPTION_PRO,
+	        self::OPTION_ALL
         ];
     }
 }

--- a/Classes/Enum/SessionTypeEnum.php
+++ b/Classes/Enum/SessionTypeEnum.php
@@ -21,6 +21,10 @@ class SessionTypeEnum
     public const OPTION_TUTORIAL = 2;
     public const OPTION_WORKSHOP = 3;
     public const OPTION_DISCUSSION = 4;
+    public const OPTION_SESSION = 5;
+    public const OPTION_BREAK = 6;
+    public const OPTION_WISH = 7;
+    public const OPTION_OTHER = 8;
 
     protected static $optionLabel = [
         self::OPTION_TALK =>
@@ -30,7 +34,15 @@ class SessionTypeEnum
         self::OPTION_WORKSHOP =>
             'LLL:EXT:sessionplaner/Resources/Private/Language/locallang.xlf:option.sessiontype.workshop',
         self::OPTION_DISCUSSION =>
-            'LLL:EXT:sessionplaner/Resources/Private/Language/locallang.xlf:option.sessiontype.discussion'
+            'LLL:EXT:sessionplaner/Resources/Private/Language/locallang.xlf:option.sessiontype.discussion',
+        self::OPTION_SESSION =>
+            'LLL:EXT:sessionplaner/Resources/Private/Language/locallang.xlf:option.sessiontype.session',
+        self::OPTION_BREAK =>
+            'LLL:EXT:sessionplaner/Resources/Private/Language/locallang.xlf:option.sessiontype.break',
+        self::OPTION_WISH =>
+            'LLL:EXT:sessionplaner/Resources/Private/Language/locallang.xlf:option.sessiontype.wish',
+        self::OPTION_OTHER =>
+            'LLL:EXT:sessionplaner/Resources/Private/Language/locallang.xlf:option.sessiontype.other'
     ];
 
     public static function getLabel(int $option): string
@@ -67,7 +79,11 @@ class SessionTypeEnum
             self::OPTION_TALK,
             self::OPTION_TUTORIAL,
             self::OPTION_WORKSHOP,
-            self::OPTION_DISCUSSION
+	        self::OPTION_DISCUSSION,
+            self::OPTION_SESSION,
+            self::OPTION_BREAK,
+            self::OPTION_WISH,
+            self::OPTION_OTHER
         ];
     }
 }

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -139,6 +139,18 @@
             <trans-unit id="option.sessiontype.discussion" xml:space="preserve">
                 <source>Discussion</source>
             </trans-unit>
+            <trans-unit id="option.sessiontype.session" xml:space="preserve">
+                <source>Session</source>
+            </trans-unit>
+            <trans-unit id="option.sessiontype.break" xml:space="preserve">
+                <source>Break</source>
+            </trans-unit>
+            <trans-unit id="option.sessiontype.wish" xml:space="preserve">
+                <source>Wish</source>
+            </trans-unit>
+            <trans-unit id="option.sessiontype.other" xml:space="preserve">
+                <source>Other</source>
+            </trans-unit>
             <trans-unit id="option.sessionlevel.beginner" xml:space="preserve">
                 <source>Beginner</source>
             </trans-unit>
@@ -147,6 +159,9 @@
             </trans-unit>
             <trans-unit id="option.sessionlevel.pro" xml:space="preserve">
                 <source>Professional</source>
+            </trans-unit>
+            <trans-unit id="option.sessionlevel.all" xml:space="preserve">
+                <source>All</source>
             </trans-unit>
 
             <!-- Label -->

--- a/Resources/Private/Partials/Session/Box.html
+++ b/Resources/Private/Partials/Session/Box.html
@@ -41,9 +41,11 @@
                             <f:if condition="{session.type} == 1">{f:translate(key: 'type-talk')}</f:if>
                             <f:if condition="{session.type} == 2">{f:translate(key: 'type-tutorial')}</f:if>
                             <f:if condition="{session.type} == 3">{f:translate(key: 'type-workshop')}</f:if>
-                            <f:if condition="{session.type} == 4">{f:translate(key: 'type-other')}</f:if>
-                            <f:if condition="{session.type} == 5">{f:translate(key: 'type-break')}</f:if>
-                            <f:if condition="{session.type} == 6">{f:translate(key: 'type-wish')}</f:if>
+                            <f:if condition="{session.type} == 4">{f:translate(key: 'type-discussion')}</f:if>
+                            <f:if condition="{session.type} == 5">{f:translate(key: 'type-session')}</f:if>
+                            <f:if condition="{session.type} == 6">{f:translate(key: 'type-break')}</f:if>
+                            <f:if condition="{session.type} == 7">{f:translate(key: 'type-wish')}</f:if>
+                            <f:if condition="{session.type} == 8">{f:translate(key: 'type-other')}</f:if>
                         </span>
                     </span>
                 </f:if>
@@ -53,6 +55,7 @@
                             <f:if condition="{session.level} == 1">{f:translate(key: 'level-starter')}</f:if>
                             <f:if condition="{session.level} == 2">{f:translate(key: 'level-advanced')}</f:if>
                             <f:if condition="{session.level} == 3">{f:translate(key: 'level-pro')}</f:if>
+                            <f:if condition="{session.level} == 4">{f:translate(key: 'level-all')}</f:if>
                         </span>
                     </span>
                 </f:if>

--- a/Resources/Private/Partials/Session/Box.html
+++ b/Resources/Private/Partials/Session/Box.html
@@ -2,7 +2,7 @@
     <div class="sessionplaner-sessionbox">
         <f:if condition="{session.speakers}">
             <f:for each="{session.speakers}" as="speaker">
-                <div class="sessionplaner-sessionbox-spaker">
+                <div class="sessionplaner-sessionbox-speaker">
                     <f:render partial="Speaker/LinkWrap" contentAs="content" arguments="{settings: settings, speaker: speaker}">
                         {speaker.name}
                     </f:render>
@@ -10,7 +10,7 @@
             </f:for>
         </f:if>
         <f:if condition="!{session.speakers} && {session.speaker}">
-            <div class="sessionplaner-sessionbox-spaker">
+            <div class="sessionplaner-sessionbox-speaker">
                 {session.speaker}
             </div>
         </f:if>


### PR DESCRIPTION
When creating new sessions in the Session Planer modul in the backend, one got the error message 

- setPid() must be of the type int, string given, called in /var/www/html/public/typo3conf/ext/sessionplaner/Classes/Controller/AjaxController.php on line 220 

and 

- getLinks() must be an instance of TYPO3\CMS\Extbase\Persistence\ObjectStorage, null returned | TypeError thrown in file /var/www/html/public/typo3conf/ext/sessionplaner/Classes/Domain/Model/Session.php in line 463