### PR TITLE
Harmonize and expand session types and session levels

### DIFF
--- a/Classes/Enum/SessionLevelEnum.php
+++ b/Classes/Enum/SessionLevelEnum.php
@@ -20,6 +20,7 @@ class SessionLevelEnum
     public const OPTION_BEGINNER = 1;
     public const OPTION_ADVANCED = 2;
     public const OPTION_PRO = 3;
+    public const OPTION_ALL = 4;
 
     protected static $optionLabel = [
         self::OPTION_BEGINNER =>
@@ -27,7 +28,9 @@ class SessionLevelEnum
         self::OPTION_ADVANCED =>
             'LLL:EXT:sessionplaner/Resources/Private/Language/locallang.xlf:option.sessionlevel.advanced',
         self::OPTION_PRO =>
-            'LLL:EXT:sessionplaner/Resources/Private/Language/locallang.xlf:option.sessionlevel.pro'
+	'LLL:EXT:sessionplaner/Resources/Private/Language/locallang.xlf:option.sessionlevel.pro',
+        self::OPTION_ALL =>
+            'LLL:EXT:sessionplaner/Resources/Private/Language/locallang.xlf:option.sessionlevel.all'
     ];
 
     public static function getLabel(int $option): string
@@ -64,7 +67,8 @@ class SessionLevelEnum
         return [
             self::OPTION_BEGINNER,
             self::OPTION_ADVANCED,
-            self::OPTION_PRO
+	        self::OPTION_PRO,
+	        self::OPTION_ALL
         ];
     }
 }

--- a/Classes/Enum/SessionTypeEnum.php
+++ b/Classes/Enum/SessionTypeEnum.php
@@ -21,6 +21,10 @@ class SessionTypeEnum
     public const OPTION_TUTORIAL = 2;
     public const OPTION_WORKSHOP = 3;
     public const OPTION_DISCUSSION = 4;
+    public const OPTION_SESSION = 5;
+    public const OPTION_BREAK = 6;
+    public const OPTION_WISH = 7;
+    public const OPTION_OTHER = 8;
 
     protected static $optionLabel = [
         self::OPTION_TALK =>
@@ -30,7 +34,15 @@ class SessionTypeEnum
         self::OPTION_WORKSHOP =>
             'LLL:EXT:sessionplaner/Resources/Private/Language/locallang.xlf:option.sessiontype.workshop',
         self::OPTION_DISCUSSION =>
-            'LLL:EXT:sessionplaner/Resources/Private/Language/locallang.xlf:option.sessiontype.discussion'
+            'LLL:EXT:sessionplaner/Resources/Private/Language/locallang.xlf:option.sessiontype.discussion',
+        self::OPTION_SESSION =>
+            'LLL:EXT:sessionplaner/Resources/Private/Language/locallang.xlf:option.sessiontype.session',
+        self::OPTION_BREAK =>
+            'LLL:EXT:sessionplaner/Resources/Private/Language/locallang.xlf:option.sessiontype.break',
+        self::OPTION_WISH =>
+            'LLL:EXT:sessionplaner/Resources/Private/Language/locallang.xlf:option.sessiontype.wish',
+        self::OPTION_OTHER =>
+            'LLL:EXT:sessionplaner/Resources/Private/Language/locallang.xlf:option.sessiontype.other'
     ];
 
     public static function getLabel(int $option): string
@@ -67,7 +79,11 @@ class SessionTypeEnum
             self::OPTION_TALK,
             self::OPTION_TUTORIAL,
             self::OPTION_WORKSHOP,
-            self::OPTION_DISCUSSION
+	        self::OPTION_DISCUSSION,
+            self::OPTION_SESSION,
+            self::OPTION_BREAK,
+            self::OPTION_WISH,
+            self::OPTION_OTHER
         ];
     }
 }

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -139,6 +139,18 @@
             <trans-unit id="option.sessiontype.discussion" xml:space="preserve">
                 <source>Discussion</source>
             </trans-unit>
+            <trans-unit id="option.sessiontype.session" xml:space="preserve">
+                <source>Session</source>
+            </trans-unit>
+            <trans-unit id="option.sessiontype.break" xml:space="preserve">
+                <source>Break</source>
+            </trans-unit>
+            <trans-unit id="option.sessiontype.wish" xml:space="preserve">
+                <source>Wish</source>
+            </trans-unit>
+            <trans-unit id="option.sessiontype.other" xml:space="preserve">
+                <source>Other</source>
+            </trans-unit>
             <trans-unit id="option.sessionlevel.beginner" xml:space="preserve">
                 <source>Beginner</source>
             </trans-unit>
@@ -147,6 +159,9 @@
             </trans-unit>
             <trans-unit id="option.sessionlevel.pro" xml:space="preserve">
                 <source>Professional</source>
+            </trans-unit>
+            <trans-unit id="option.sessionlevel.all" xml:space="preserve">
+                <source>All</source>
             </trans-unit>
 
             <!-- Label -->

--- a/Resources/Private/Partials/Session/Box.html
+++ b/Resources/Private/Partials/Session/Box.html
@@ -38,24 +38,24 @@
                 <f:if condition="{session.type}">
                     <span class="sessionplaner-sessionbox-tags-type">
                         <span class="sessionplaner-tag">
-                            <f:if condition="{session.type} == 1">{f:translate(key: 'type-talk')}</f:if>
-                            <f:if condition="{session.type} == 2">{f:translate(key: 'type-tutorial')}</f:if>
-                            <f:if condition="{session.type} == 3">{f:translate(key: 'type-workshop')}</f:if>
-                            <f:if condition="{session.type} == 4">{f:translate(key: 'type-discussion')}</f:if>
-                            <f:if condition="{session.type} == 5">{f:translate(key: 'type-session')}</f:if>
-                            <f:if condition="{session.type} == 6">{f:translate(key: 'type-break')}</f:if>
-                            <f:if condition="{session.type} == 7">{f:translate(key: 'type-wish')}</f:if>
-                            <f:if condition="{session.type} == 8">{f:translate(key: 'type-other')}</f:if>
+                            <f:if condition="{session.type} == 1">{f:translate(key: 'option.sessiontype.talk')}</f:if>
+                            <f:if condition="{session.type} == 2">{f:translate(key: 'option.sessiontype.tutorial')}</f:if>
+                            <f:if condition="{session.type} == 3">{f:translate(key: 'option.sessiontype.workshop')}</f:if>
+                            <f:if condition="{session.type} == 4">{f:translate(key: 'option.sessiontype.discussion')}</f:if>
+                            <f:if condition="{session.type} == 5">{f:translate(key: 'option.sessiontype.session')}</f:if>
+                            <f:if condition="{session.type} == 6">{f:translate(key: 'option.sessiontype.break')}</f:if>
+                            <f:if condition="{session.type} == 7">{f:translate(key: 'option.sessiontype.wish')}</f:if>
+                            <f:if condition="{session.type} == 8">{f:translate(key: 'option.sessiontype.other')}</f:if>
                         </span>
                     </span>
                 </f:if>
                 <f:if condition="{session.level}">
                     <span class="sessionplaner-sessionbox-tags-level">
                         <span class="sessionplaner-tag">
-                            <f:if condition="{session.level} == 1">{f:translate(key: 'level-starter')}</f:if>
-                            <f:if condition="{session.level} == 2">{f:translate(key: 'level-advanced')}</f:if>
-                            <f:if condition="{session.level} == 3">{f:translate(key: 'level-pro')}</f:if>
-                            <f:if condition="{session.level} == 4">{f:translate(key: 'level-all')}</f:if>
+                            <f:if condition="{session.level} == 1">{f:translate(key: 'option.sessionlevel.starter')}</f:if>
+                            <f:if condition="{session.level} == 2">{f:translate(key: 'option.sessionlevel.advanced')}</f:if>
+                            <f:if condition="{session.level} == 3">{f:translate(key: 'option.sessionlevel.pro')}</f:if>
+                            <f:if condition="{session.level} == 4">{f:translate(key: 'option.sessionlevel.all')}</f:if>
                         </span>
                     </span>
                 </f:if>

--- a/Resources/Private/Partials/Session/Box.html
+++ b/Resources/Private/Partials/Session/Box.html
@@ -41,9 +41,11 @@
                             <f:if condition="{session.type} == 1">{f:translate(key: 'type-talk')}</f:if>
                             <f:if condition="{session.type} == 2">{f:translate(key: 'type-tutorial')}</f:if>
                             <f:if condition="{session.type} == 3">{f:translate(key: 'type-workshop')}</f:if>
-                            <f:if condition="{session.type} == 4">{f:translate(key: 'type-other')}</f:if>
-                            <f:if condition="{session.type} == 5">{f:translate(key: 'type-break')}</f:if>
-                            <f:if condition="{session.type} == 6">{f:translate(key: 'type-wish')}</f:if>
+                            <f:if condition="{session.type} == 4">{f:translate(key: 'type-discussion')}</f:if>
+                            <f:if condition="{session.type} == 5">{f:translate(key: 'type-session')}</f:if>
+                            <f:if condition="{session.type} == 6">{f:translate(key: 'type-break')}</f:if>
+                            <f:if condition="{session.type} == 7">{f:translate(key: 'type-wish')}</f:if>
+                            <f:if condition="{session.type} == 8">{f:translate(key: 'type-other')}</f:if>
                         </span>
                     </span>
                 </f:if>
@@ -53,6 +55,7 @@
                             <f:if condition="{session.level} == 1">{f:translate(key: 'level-starter')}</f:if>
                             <f:if condition="{session.level} == 2">{f:translate(key: 'level-advanced')}</f:if>
                             <f:if condition="{session.level} == 3">{f:translate(key: 'level-pro')}</f:if>
+                            <f:if condition="{session.level} == 4">{f:translate(key: 'level-all')}</f:if>
                         </span>
                     </span>
                 </f:if>


### PR DESCRIPTION
So far, there were more options for session types in Partials/Box.html than there were in Classes/Enum.
This PR adds these two "Break" and "Other", as well as the type "Session" to session types.
It furthermore adds the level "All" to session levels.