### PR TITLE
Fix initialization of mail finisher.

### DIFF
--- a/Classes/Domain/Factory/SuggestFormFactory.php
+++ b/Classes/Domain/Factory/SuggestFormFactory.php
@@ -187,8 +187,11 @@ class SuggestFormFactory extends AbstractFormFactory
         ) {
             $form->createFinisher('EmailToReceiver', [
                 'subject' => $settings['suggest']['notification']['subject'] ?? '',
-                'recipientAddress' => $settings['suggest']['notification']['recipientAddress'] ?? '',
-                'recipientName' => $settings['suggest']['notification']['recipientName'] ?? '',
+                'recipients' => $settings['suggest']['notification']['recipientAddress']
+                    ? [
+                        $settings['suggest']['notification']['recipientAddress'] => $settings['suggest']['notification']['recipientName'],
+                    ]
+                    : [],
                 'senderAddress' => $settings['suggest']['notification']['senderAddress'] ?? '',
                 'senderName' => $settings['suggest']['notification']['senderName'] ?? '',
                 'carbonCopyAddress' => $settings['suggest']['notification']['carbonCopyAddress'] ?? '',


### PR DESCRIPTION
#19  TYPO3 11 it is not supported any more to set directly a single recipient. Instead the new multi-value features have to be used, introduced in TYPO3 10:
https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/10.0/Deprecation-80420-EmailFinisherSingleAddressOptions.html