### PR TITLE
Avoid error when room logo is not assigned

### DIFF
--- a/Classes/Domain/Model/Room.php
+++ b/Classes/Domain/Model/Room.php
@@ -85,7 +85,7 @@ class Room extends AbstractEntity
         $this->logo = $logo;
     }
 
-    public function getLogo(): FileReference
+    public function getLogo(): ?FileReference
     {
         return $this->logo;
     }


### PR DESCRIPTION
This patch avoids the error:
Return value of Evoweb\Sessionplaner\Domain\Model\Room::getLogo() must be an instance of TYPO3\CMS\Extbase\Domain\Model\FileReference, null returned