### PR TITLE
[BUGFIX] Register `SuggestFormFactory` as service

### DIFF
--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -10,5 +10,8 @@ services:
   Evoweb\Sessionplaner\Controller\AjaxController:
     public: true
 
+  Evoweb\Sessionplaner\Domain\Factory\SuggestFormFactory:
+    public: true
+
   Evoweb\Sessionplaner\Domain\Finisher\SuggestFormFinisher:
     public: true


### PR DESCRIPTION
The `SuggestFormFactory` is renderd via a ViewHelper within Fluid, where DI is not available. Therefore, the factory class needs to be registered explicitly.