### PR TITLE
[BUGFIX] Make `StringLengthValidator` configuration v12+ compatible

### DIFF
--- a/Classes/Domain/Factory/SuggestFormFactory.php
+++ b/Classes/Domain/Factory/SuggestFormFactory.php
@@ -15,6 +15,7 @@ use Evoweb\Sessionplaner\Domain\Finisher\SuggestFormFinisher;
 use Evoweb\Sessionplaner\Enum\SessionLevelEnum;
 use Evoweb\Sessionplaner\Enum\SessionRequestTypeEnum;
 use Evoweb\Sessionplaner\Enum\SessionTypeEnum;
+use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
@@ -157,7 +158,14 @@ class SuggestFormFactory extends AbstractFormFactory
             $this->getLocalizedLabel($settings['suggest']['fields']['description']['description'])
         );
         $descriptionField->addValidator(GeneralUtility::makeInstance(NotEmptyValidator::class));
-        $descriptionField->addValidator(GeneralUtility::makeInstance(StringLengthValidator::class, ['minimum' => 5]));
+
+        if ((GeneralUtility::makeInstance(Typo3Version::class))->getMajorVersion() < 12) {
+            $stringLengthValidator = GeneralUtility::makeInstance(StringLengthValidator::class, ['minimum' => 5]);
+        } else {
+            $stringLengthValidator = GeneralUtility::makeInstance(StringLengthValidator::class);
+            $stringLengthValidator->setOptions(['minimum' => 5]);
+        }
+        $descriptionField->addValidator($stringLengthValidator);
 
         if ($settings['suggest']['fields']['length']['enable']) {
             /** @var GenericFormElement $lengthField */


### PR DESCRIPTION
The validator API has changed in v12, configuration doesn't happen via constructor arguments anymore, but via calling `setOptions()`.

This commit adds a version switch to respect several versions of the API.