### PR TITLE
[FEATURE] Suggest tag for session

### DIFF
--- a/Classes/Domain/Factory/SuggestFormFactory.php
+++ b/Classes/Domain/Factory/SuggestFormFactory.php
@@ -146,26 +146,28 @@ class SuggestFormFactory extends AbstractFormFactory
             $typeField->setProperty('options', $typeFieldOptions);
         }
 
-        $tags = $this->tagRepository->findBy(['suggestFormOption' => true]);
-        if ($settings['suggest']['fields']['tag']['enable'] && $tags->current()) {
-            /** @var GenericFormElement $tagField */
-            $tagField = $sessionInformation->createElement('tag', 'SingleSelect');
-            $tagField->setLabel($this->getLocalizedLabel($settings['suggest']['fields']['tag']['label']));
-            $tagField->setProperty(
-                'elementDescription',
-                $this->getLocalizedLabel($settings['suggest']['fields']['tag']['description'])
-            );
-            $tagField->addValidator(GeneralUtility::makeInstance(NotEmptyValidator::class));
-            $tagFieldOptions = [];
-            foreach ($tags as $tag) {
-                $tagFieldOptions[$tag->getUid()] = $tag->getLabel();
+        if ($settings['suggest']['fields']['tag']['enable']) {
+            $tags = $this->tagRepository->findBy(['suggestFormOption' => true]);
+            if ($tags->current()) {
+                /** @var GenericFormElement $tagField */
+                $tagField = $sessionInformation->createElement('tag', 'SingleSelect');
+                $tagField->setLabel($this->getLocalizedLabel($settings['suggest']['fields']['tag']['label']));
+                $tagField->setProperty(
+                    'elementDescription',
+                    $this->getLocalizedLabel($settings['suggest']['fields']['tag']['description'])
+                );
+                $tagField->addValidator(GeneralUtility::makeInstance(NotEmptyValidator::class));
+                $tagFieldOptions = [];
+                foreach ($tags as $tag) {
+                    $tagFieldOptions[$tag->getUid()] = $tag->getLabel();
+                }
+                $prependOptionLabel = ' ';
+                if (!empty($settings['suggest']['fields']['tag']['prependOptionLabel'])) {
+                    $prependOptionLabel = $this->getLocalizedLabel($settings['suggest']['fields']['tag']['prependOptionLabel']);
+                }
+                $tagField->setProperty('prependOptionLabel', $prependOptionLabel);
+                $tagField->setProperty('options', $tagFieldOptions);
             }
-            $prependOptionLabel = ' ';
-            if (!empty($settings['suggest']['fields']['tag']['prependOptionLabel'])) {
-                $prependOptionLabel = $this->getLocalizedLabel($settings['suggest']['fields']['tag']['prependOptionLabel']);
-            }
-            $tagField->setProperty('prependOptionLabel', $prependOptionLabel);
-            $tagField->setProperty('options', $tagFieldOptions);
         }
 
         /** @var GenericFormElement $titleField */

--- a/Classes/Domain/Factory/SuggestFormFactory.php
+++ b/Classes/Domain/Factory/SuggestFormFactory.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Evoweb\Sessionplaner\Domain\Factory;
 
 use Evoweb\Sessionplaner\Domain\Finisher\SuggestFormFinisher;
+use Evoweb\Sessionplaner\Domain\Repository\TagRepository;
 use Evoweb\Sessionplaner\Enum\SessionLevelEnum;
 use Evoweb\Sessionplaner\Enum\SessionRequestTypeEnum;
 use Evoweb\Sessionplaner\Enum\SessionTypeEnum;
@@ -35,12 +36,16 @@ class SuggestFormFactory extends AbstractFormFactory
 
     protected ConfigurationManagerInterface $configurationManager;
 
+    protected TagRepository $tagRepository;
+
     public function __construct(
         ConfigurationManagerInterface $configurationManager,
-        ConfigurationService $formConfigurationService
+        ConfigurationService $formConfigurationService,
+        TagRepository $tagRepository
     ) {
         $this->configurationManager = $configurationManager;
         $this->formConfigurationService = $formConfigurationService;
+        $this->tagRepository = $tagRepository;
     }
 
     public function build(array $configuration, string $prototypeName = null): FormDefinition
@@ -139,6 +144,28 @@ class SuggestFormFactory extends AbstractFormFactory
             }
             $typeField->setProperty('prependOptionLabel', $prependOptionLabel);
             $typeField->setProperty('options', $typeFieldOptions);
+        }
+
+        $tags = $this->tagRepository->findBy(['suggestFormOption' => true]);
+        if ($settings['suggest']['fields']['tag']['enable'] && $tags->current()) {
+            /** @var GenericFormElement $tagField */
+            $tagField = $sessionInformation->createElement('tag', 'SingleSelect');
+            $tagField->setLabel($this->getLocalizedLabel($settings['suggest']['fields']['tag']['label']));
+            $tagField->setProperty(
+                'elementDescription',
+                $this->getLocalizedLabel($settings['suggest']['fields']['tag']['description'])
+            );
+            $tagField->addValidator(GeneralUtility::makeInstance(NotEmptyValidator::class));
+            $tagFieldOptions = [];
+            foreach ($tags as $tag) {
+                $tagFieldOptions[$tag->getUid()] = $tag->getLabel();
+            }
+            $prependOptionLabel = ' ';
+            if (!empty($settings['suggest']['fields']['tag']['prependOptionLabel'])) {
+                $prependOptionLabel = $this->getLocalizedLabel($settings['suggest']['fields']['tag']['prependOptionLabel']);
+            }
+            $tagField->setProperty('prependOptionLabel', $prependOptionLabel);
+            $tagField->setProperty('options', $tagFieldOptions);
         }
 
         /** @var GenericFormElement $titleField */

--- a/Classes/Domain/Finisher/SuggestFormFinisher.php
+++ b/Classes/Domain/Finisher/SuggestFormFinisher.php
@@ -15,6 +15,7 @@ use Evoweb\Sessionplaner\Domain\Model\Session;
 use Evoweb\Sessionplaner\Domain\Model\Speaker;
 use Evoweb\Sessionplaner\Domain\Repository\SessionRepository;
 use Evoweb\Sessionplaner\Domain\Repository\SpeakerRepository;
+use Evoweb\Sessionplaner\Domain\Repository\TagRepository;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
@@ -27,6 +28,8 @@ class SuggestFormFinisher extends AbstractFinisher
     protected ?SpeakerRepository $speakerRepository = null;
 
     protected ?SessionRepository $sessionRepository = null;
+
+    protected ?TagRepository $tagRepository = null;
 
     protected ?PersistenceManagerInterface $persistenceManager = null;
 
@@ -43,6 +46,11 @@ class SuggestFormFinisher extends AbstractFinisher
     public function injectSessionRepository(SessionRepository $sessionRepository)
     {
         $this->sessionRepository = $sessionRepository;
+    }
+
+    public function injectTagRepository(TagRepository $tagRepository)
+    {
+        $this->tagRepository = $tagRepository;
     }
 
     public function injectPersistenceManager(PersistenceManagerInterface $persistenceManager)
@@ -83,6 +91,9 @@ class SuggestFormFinisher extends AbstractFinisher
         $session->setDescription($data['description']);
         if (!empty($data['type'])) {
             $session->setType($data['type']);
+        }
+        if (!empty($data['tag']) && null !== ($tag = $this->tagRepository->findByUid($data['tag']))) {
+            $session->addTag($tag);
         }
         if (!empty($data['level'])) {
             $session->setLevel($data['level']);

--- a/Classes/Domain/Model/Session.php
+++ b/Classes/Domain/Model/Session.php
@@ -327,6 +327,16 @@ class Session extends AbstractSlugEntity
         return $this->tags;
     }
 
+    public function addTag(Tag $tag): void
+    {
+        $this->tags->attach($tag);
+    }
+
+    public function removeTag(Tag $tag): void
+    {
+        $this->tags->detach($tag);
+    }
+
     public function toArray(): array
     {
         $data = [];

--- a/Classes/Domain/Model/Tag.php
+++ b/Classes/Domain/Model/Tag.php
@@ -37,6 +37,11 @@ class Tag extends AbstractEntity
     protected string $slug = '';
 
     /**
+     * @var bool
+     */
+    protected bool $suggestFormOption = false;
+
+    /**
      * @var ObjectStorage<Session>
      * @TYPO3\CMS\Extbase\Annotation\ORM\Lazy
      */
@@ -90,6 +95,16 @@ class Tag extends AbstractEntity
     public function getSlug(): string
     {
         return $this->slug;
+    }
+
+    public function setSuggestFormOption(bool $suggestFormOption): void
+    {
+        $this->suggestFormOption = $suggestFormOption;
+    }
+
+    public function isSuggestFormOption(): bool
+    {
+        return $this->suggestFormOption;
     }
 
     public function setSessions(ObjectStorage $sessions)

--- a/Classes/Domain/Repository/TagRepository.php
+++ b/Classes/Domain/Repository/TagRepository.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the package evoweb/sessionplaner.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Evoweb\Sessionplaner\Domain\Repository;
+
+use TYPO3\CMS\Extbase\Persistence\QueryInterface;
+use TYPO3\CMS\Extbase\Persistence\Repository;
+
+class TagRepository extends Repository
+{
+    protected $defaultOrderings = [
+        'label' => QueryInterface::ORDER_ASCENDING
+    ];
+}

--- a/Configuration/TCA/tx_sessionplaner_domain_model_tag.php
+++ b/Configuration/TCA/tx_sessionplaner_domain_model_tag.php
@@ -99,6 +99,23 @@ return [
                 'default' => ''
             ]
         ],
+        'suggest_form_option' => [
+            'exclude' => false,
+            'label' => $languageFile . 'tx_sessionplaner_domain_model_tag-suggest_form_option',
+            'config' => [
+                'type' => 'check',
+                'renderType' => 'checkboxToggle',
+                'items' => [
+                    [
+                        'label' => '',
+                        'invertStateDisplay' => false,
+                    ],
+                ],
+                'behaviour' => [
+                    'allowLanguageSynchronization' => true,
+                ],
+            ],
+        ],
         'sessions' => [
             'exclude' => false,
             'label' => $languageFile . 'tx_sessionplaner_domain_model_tag-sessions',
@@ -120,6 +137,7 @@ return [
                 path_segment,
                 color,
                 description,
+                suggest_form_option,
                 sessions
             '
         ]

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -64,6 +64,12 @@ plugin.tx_sessionplaner {
                     description = LLL:EXT:sessionplaner/Resources/Private/Language/locallang.xlf:form.type.description
                     prependOptionLabel =
                 }
+                tag {
+                    enable = 0
+                    label = LLL:EXT:sessionplaner/Resources/Private/Language/locallang.xlf:form.tag
+                    description = LLL:EXT:sessionplaner/Resources/Private/Language/locallang.xlf:form.tag.description
+                    prependOptionLabel =
+                }
                 title {
                     label = LLL:EXT:sessionplaner/Resources/Private/Language/locallang.xlf:form.title
                     description = LLL:EXT:sessionplaner/Resources/Private/Language/locallang.xlf:form.title.description

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -223,6 +223,12 @@
             <trans-unit id="form.type.description">
                 <source>What type of session to you want to offer?</source>
             </trans-unit>
+            <trans-unit id="form.tag">
+                <source>Tag</source>
+            </trans-unit>
+            <trans-unit id="form.tag.description">
+                <source>What tag would you like to add to your session?</source>
+            </trans-unit>
             <trans-unit id="form.level">
                 <source>Level</source>
             </trans-unit>

--- a/Resources/Private/Language/locallang_tca.xlf
+++ b/Resources/Private/Language/locallang_tca.xlf
@@ -211,6 +211,9 @@
             <trans-unit id="tx_sessionplaner_domain_model_tag-path_segment" xml:space="preserve">
                 <source>Path segment</source>
             </trans-unit>
+            <trans-unit id="tx_sessionplaner_domain_model_tag-suggest_form_option" xml:space="preserve">
+                <source>Use as option in suggest form</source>
+            </trans-unit>
             <trans-unit id="tx_sessionplaner_domain_model_tag-sessions" xml:space="preserve">
                 <source>Sessions</source>
             </trans-unit>

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -73,11 +73,12 @@ CREATE TABLE tx_sessionplaner_domain_model_session
 #
 CREATE TABLE tx_sessionplaner_domain_model_tag
 (
-    label           varchar(255) DEFAULT '' NOT NULL,
-    color           varchar(255) DEFAULT '' NOT NULL,
-    description     text,
-    path_segment    varchar(2048),
-    sessions        int(11) unsigned DEFAULT '0' NOT NULL
+    label                  varchar(255) DEFAULT '' NOT NULL,
+    color                  varchar(255) DEFAULT '' NOT NULL,
+    description            text,
+    path_segment           varchar(2048),
+    suggest_form_option    smallint unsigned DEFAULT '0' NOT NULL,
+    sessions               int(11) unsigned DEFAULT '0' NOT NULL
 );
 
 #


### PR DESCRIPTION
This feature adds a new select to the suggest session form allowing the user to select a tag.
Only tags marked as "Use as option in suggest form" will be available. If there are none or the field is not enabled via TypoScript, the field will not be added to the form.

**Frontend**
![frontend](https://github.com/user-attachments/assets/ccd171c0-bc59-4c4a-a18c-19328ec0cbb0)

**Backend**
![backend](https://github.com/user-attachments/assets/8d115bb1-99ab-4d76-aec3-1a797290e367)
