### PR TITLE
[FEATURE] Extend suggestion form

### DIFF
--- a/Classes/Domain/Factory/SuggestFormFactory.php
+++ b/Classes/Domain/Factory/SuggestFormFactory.php
@@ -197,6 +197,31 @@ class SuggestFormFactory extends AbstractFormFactory
             $titleField->addValidator($titleNotEmptyValidator);
         }
 
+        if ((bool)($settings['suggest']['fields']['subtitle']['enable'] ?? false) === true) {
+            /** @var GenericFormElement $subtitleField */
+            $subtitleField = $sessionInformation->createElement('subtitle', 'Text');
+            $subtitleField->setLabel($this->getLocalizedLabel($settings['suggest']['fields']['subtitle']['label']));
+            $subtitleField->setProperty(
+                'elementDescription',
+                $this->getLocalizedLabel($settings['suggest']['fields']['subtitle']['description'])
+            );
+            $subtitleStringLengthValidatorOptions = ['minimum' => $settings['suggest']['fields']['subtitle']['validation']['min'] ?? 1];
+            if ($settings['suggest']['fields']['subtitle']['validation']['max'] ?? false) {
+                $subtitleStringLengthValidatorOptions['maximum'] = (int)$settings['suggest']['fields']['subtitle']['validation']['max'];
+            }
+            /** @var StringLengthValidator $subtitleStringLengthValidator */
+            $subtitleStringLengthValidator = $this->validatorResolver->createValidator(
+                StringLengthValidator::class,
+                $subtitleStringLengthValidatorOptions
+            );
+            $subtitleField->addValidator($subtitleStringLengthValidator);
+            if ($subtitleStringLengthValidatorOptions['minimum'] > 0) {
+                /** @var NotEmptyValidator $subtitleNotEmptyValidator */
+                $subtitleNotEmptyValidator = $this->validatorResolver->createValidator(NotEmptyValidator::class);
+                $subtitleField->addValidator($subtitleNotEmptyValidator);
+            }
+        }
+
         /** @var GenericFormElement $descriptionField */
         $descriptionField = $sessionInformation->createElement('description', 'Textarea');
         $descriptionField->setLabel($this->getLocalizedLabel($settings['suggest']['fields']['description']['label']));

--- a/Classes/Domain/Factory/SuggestFormFactory.php
+++ b/Classes/Domain/Factory/SuggestFormFactory.php
@@ -44,11 +44,9 @@ class SuggestFormFactory extends AbstractFormFactory
 
     public function build(
         array $configuration,
-        ?string $prototypeName = null,
+        ?string $prototypeName = 'standard',
         ?ServerRequestInterface $request = null
     ): FormDefinition {
-        $prototypeName = 'standard';
-
         $prototypeConfiguration = $this->formConfigurationService->getPrototypeConfiguration($prototypeName);
 
         $settings = $this->configurationManager->getConfiguration(
@@ -186,9 +184,18 @@ class SuggestFormFactory extends AbstractFormFactory
             'elementDescription',
             $this->getLocalizedLabel($settings['suggest']['fields']['title']['description'])
         );
-        /** @var NotEmptyValidator $titleValidator */
-        $titleValidator = $this->validatorResolver->createValidator(NotEmptyValidator::class);
-        $titleField->addValidator($titleValidator);
+        $titleStringLengthValidatorOptions = ['minimum' => $settings['suggest']['fields']['title']['validation']['min'] ?? 1];
+        if ($settings['suggest']['fields']['title']['validation']['max'] ?? false) {
+            $titleStringLengthValidatorOptions['maximum'] = (int)$settings['suggest']['fields']['title']['validation']['max'];
+        }
+        /** @var StringLengthValidator $titleStringLengthValidator */
+        $titleStringLengthValidator = $this->validatorResolver->createValidator(StringLengthValidator::class, $titleStringLengthValidatorOptions);
+        $titleField->addValidator($titleStringLengthValidator);
+        if ($titleStringLengthValidatorOptions['minimum'] > 0) {
+            /** @var NotEmptyValidator $titleNotEmptyValidator */
+            $titleNotEmptyValidator = $this->validatorResolver->createValidator(NotEmptyValidator::class);
+            $titleField->addValidator($titleNotEmptyValidator);
+        }
 
         /** @var GenericFormElement $descriptionField */
         $descriptionField = $sessionInformation->createElement('description', 'Textarea');

--- a/Classes/Domain/Factory/SuggestFormFactory.php
+++ b/Classes/Domain/Factory/SuggestFormFactory.php
@@ -240,6 +240,31 @@ class SuggestFormFactory extends AbstractFormFactory
         );
         $descriptionField->addValidator($stringLengthValidator);
 
+        if ((bool)($settings['suggest']['fields']['tag_suggestion']['enable'] ?? false) === true) {
+            /** @var GenericFormElement $tagSuggestionField */
+            $tagSuggestionField = $sessionInformation->createElement('tag_suggestion', 'Text');
+            $tagSuggestionField->setLabel($this->getLocalizedLabel($settings['suggest']['fields']['tag_suggestion']['label']));
+            $tagSuggestionField->setProperty(
+                'elementDescription',
+                $this->getLocalizedLabel($settings['suggest']['fields']['tag_suggestion']['description'])
+            );
+            $tagSuggestionStringLengthValidatorOptions = ['minimum' => $settings['suggest']['fields']['tag_suggestion']['validation']['min'] ?? 1];
+            if ($settings['suggest']['fields']['tag_suggestion']['validation']['max'] ?? false) {
+                $tagSuggestionStringLengthValidatorOptions['maximum'] = (int)$settings['suggest']['fields']['tag_suggestion']['validation']['max'];
+            }
+            /** @var StringLengthValidator $tagSuggestionStringLengthValidator */
+            $tagSuggestionStringLengthValidator = $this->validatorResolver->createValidator(
+                StringLengthValidator::class,
+                $tagSuggestionStringLengthValidatorOptions
+            );
+            $tagSuggestionField->addValidator($tagSuggestionStringLengthValidator);
+            if ($tagSuggestionStringLengthValidatorOptions['minimum'] > 0) {
+                /** @var NotEmptyValidator $tagSuggestionNotEmptyValidator */
+                $tagSuggestionNotEmptyValidator = $this->validatorResolver->createValidator(NotEmptyValidator::class);
+                $tagSuggestionField->addValidator($tagSuggestionNotEmptyValidator);
+            }
+        }
+
         if ((bool)($settings['suggest']['fields']['length']['enable'] ?? false) === true) {
             /** @var GenericFormElement $lengthField */
             $lengthField = $sessionInformation->createElement('estimatedlength', 'SingleSelect');

--- a/Classes/Domain/Factory/SuggestFormFactory.php
+++ b/Classes/Domain/Factory/SuggestFormFactory.php
@@ -44,9 +44,11 @@ class SuggestFormFactory extends AbstractFormFactory
 
     public function build(
         array $configuration,
-        ?string $prototypeName = 'standard',
+        ?string $prototypeName = null,
         ?ServerRequestInterface $request = null
     ): FormDefinition {
+        $prototypeName = 'standard';
+
         $prototypeConfiguration = $this->formConfigurationService->getPrototypeConfiguration($prototypeName);
 
         $settings = $this->configurationManager->getConfiguration(

--- a/Classes/Domain/Factory/SuggestFormFactory.php
+++ b/Classes/Domain/Factory/SuggestFormFactory.php
@@ -344,15 +344,38 @@ class SuggestFormFactory extends AbstractFormFactory
             ]);
         }
 
+        $message = $settings['suggest']['confirmation']['message'] ??
+            'LLL:EXT:sessionplaner/Resources/Private/Language/locallang.xlf:form.suggest.confirmation';
+        $confirmationMessage = LocalizationUtility::translate($message) ?? '';
+
+        if ($this->sendingSenderNotificationAllowed($settings)) {
+            $form->createFinisher('EmailToSender', [
+                'subject' => $settings['suggest']['senderNotification']['subject'],
+                'recipients' => [
+                    '{email}' => '{fullname}',
+                ],
+                'senderAddress' => $settings['suggest']['senderNotification']['senderAddress'],
+                'senderName' => $settings['suggest']['senderNotification']['senderName'],
+                'format' => 'html',
+                'headline' => $settings['suggest']['senderNotification']['subject'],
+                'variables' => [
+                    'title' => $settings['suggest']['senderNotification']['subject'],
+                    'message' => $confirmationMessage,
+                ],
+                'templateName' => 'EmailToSender',
+                'templateRootPaths' => [
+                    100 => 'EXT:sessionplaner/Resources/Private/Templates/Email/'
+                ],
+            ]);
+        }
+
         if (($settings['suggest']['confirmation']['pageUid'] ?? '') !== '') {
             $form->createFinisher('Redirect', [
                 'pageUid' => (int)$settings['suggest']['confirmation']['pageUid'],
             ]);
         } else {
-            $message = $settings['suggest']['confirmation']['message'] ??
-                'LLL:EXT:sessionplaner/Resources/Private/Language/locallang.xlf:form.suggest.confirmation';
             $form->createFinisher('Confirmation', [
-                'message' => LocalizationUtility::translate($message) ?? '',
+                'message' => $confirmationMessage,
             ]);
         }
 
@@ -376,6 +399,20 @@ class SuggestFormFactory extends AbstractFormFactory
             && $settings['suggest']['notification']['recipientName'] !== ''
             && $settings['suggest']['notification']['senderAddress'] !== ''
             && $settings['suggest']['notification']['senderName'] !== '';
+    }
+
+    protected function sendingSenderNotificationAllowed(array $settings): bool
+    {
+        return isset(
+                $settings['suggest']['senderNotification']['enable'],
+                $settings['suggest']['senderNotification']['subject'],
+                $settings['suggest']['senderNotification']['senderAddress'],
+                $settings['suggest']['senderNotification']['senderName']
+            )
+            && (bool)$settings['suggest']['senderNotification']['enable'] === true
+            && $settings['suggest']['senderNotification']['subject'] !== ''
+            && $settings['suggest']['senderNotification']['senderAddress'] !== ''
+            && $settings['suggest']['senderNotification']['senderName'] !== '';
     }
 
     protected function getLocalizedLabel(string $label): string

--- a/Classes/Domain/Finisher/SuggestFormFinisher.php
+++ b/Classes/Domain/Finisher/SuggestFormFinisher.php
@@ -72,6 +72,7 @@ class SuggestFormFinisher extends AbstractFinisher
         $session->setTopic((string)($data['title'] ?? ''));
         $session->setTopicAddition((string)($data['subtitle'] ?? ''));
         $session->setDescription((string)($data['description'] ?? ''));
+        $session->setTagSuggestion((string)($data['tag_suggestion'] ?? ''));
 
         if (isset($data['type']) && $data['type'] !== '') {
             $session->setType((int)$data['type']);

--- a/Classes/Domain/Finisher/SuggestFormFinisher.php
+++ b/Classes/Domain/Finisher/SuggestFormFinisher.php
@@ -70,6 +70,7 @@ class SuggestFormFinisher extends AbstractFinisher
         }
 
         $session->setTopic((string)($data['title'] ?? ''));
+        $session->setTopicAddition((string)($data['subtitle'] ?? ''));
         $session->setDescription((string)($data['description'] ?? ''));
 
         if (isset($data['type']) && $data['type'] !== '') {

--- a/Classes/Domain/Model/Session.php
+++ b/Classes/Domain/Model/Session.php
@@ -41,6 +41,8 @@ class Session extends AbstractSlugEntity
 
     protected string $description = '';
 
+    protected string $tagSuggestion = '';
+
     protected string $speaker = '';
 
     protected string $twitter = '';
@@ -176,6 +178,16 @@ class Session extends AbstractSlugEntity
     public function getDescription(): string
     {
         return $this->description;
+    }
+
+    public function setTagSuggestion(string $tagSuggestion): void
+    {
+        $this->tagSuggestion = $tagSuggestion;
+    }
+
+    public function getTagSuggestion(): string
+    {
+        return $this->tagSuggestion;
     }
 
     public function addSpeaker(Speaker $speaker): void

--- a/Classes/Domain/Model/Session.php
+++ b/Classes/Domain/Model/Session.php
@@ -35,6 +35,8 @@ class Session extends AbstractSlugEntity
      */
     protected string $topic = '';
 
+    protected string $topicAddition = '';
+
     protected string $pathSegment = '';
 
     protected string $description = '';
@@ -144,6 +146,16 @@ class Session extends AbstractSlugEntity
     public function getTopic(): string
     {
         return $this->topic;
+    }
+
+    public function setTopicAddition(string $topicAddition): void
+    {
+        $this->topicAddition = $topicAddition;
+    }
+
+    public function getTopicAddition(): string
+    {
+        return $this->topicAddition;
     }
 
     public function setPathSegment(string $pathSegment): void

--- a/Configuration/TCA/tx_sessionplaner_domain_model_session.php
+++ b/Configuration/TCA/tx_sessionplaner_domain_model_session.php
@@ -167,6 +167,17 @@ return [
                 'richtextConfiguration' => 'default',
             ],
         ],
+        'tag_suggestion' => [
+            'exclude' => false,
+            'label' => $languageFile . 'tx_sessionplaner_domain_model_session-tag_suggestion',
+            'config' => [
+                'type' => 'input',
+                'size' => 40,
+                'eval' => 'trim',
+                'required' => false,
+                'max' => 256,
+            ],
+        ],
         'documents' => [
             'exclude' => false,
             'label' => $languageFile . 'tx_sessionplaner_domain_model_session-download',

--- a/Configuration/TCA/tx_sessionplaner_domain_model_session.php
+++ b/Configuration/TCA/tx_sessionplaner_domain_model_session.php
@@ -72,6 +72,17 @@ return [
                 'max' => 256,
             ],
         ],
+        'topic_addition' => [
+            'exclude' => false,
+            'label' => $languageFile . 'tx_sessionplaner_domain_model_session-topic_addition',
+            'config' => [
+                'type' => 'input',
+                'size' => 40,
+                'eval' => 'trim',
+                'required' => false,
+                'max' => 256,
+            ],
+        ],
         'path_segment' => [
             'exclude' => false,
             'label' => $languageFile . 'tx_sessionplaner_domain_model_session-path_segment',
@@ -341,6 +352,7 @@ return [
                 --div--;General,
                     --palette--;' . $languageFile . 'tx_sessionplaner_domain_model_session.palettes.options;options,
                     topic,
+                    topic_addition,
                     path_segment,
                     description,
                     --palette--;' . $languageFile

--- a/Configuration/TCA/tx_sessionplaner_domain_model_session.php
+++ b/Configuration/TCA/tx_sessionplaner_domain_model_session.php
@@ -379,6 +379,7 @@ return [
                     day,
                     room,
                     slot,
+                    tag_suggestion,
                     tags,
             ',
         ],

--- a/Configuration/TypoScript/constants.typoscript
+++ b/Configuration/TypoScript/constants.typoscript
@@ -2,6 +2,7 @@
 # customsubcategory=110_SPPERSISTENCE=Persistence
 # customsubcategory=120_SPSETTINGS=Settings
 # customsubcategory=130_SPSUGGESTMAIL=Suggest Notifications
+# customsubcategory=135_SPSUGGESTSENDERMAIL=Suggest Notifications to Sender
 # customsubcategory=140_SPSUGGESTCONFIRMATION=Suggest Confirmation
 
 plugin.tx_sessionplaner {
@@ -47,6 +48,16 @@ plugin.tx_sessionplaner {
                 carbonCopyAddress =
                 # cat=plugin.sessionplaner/130_SPSUGGESTMAIL/blindCarbonCopyAddress; type=string; label=Blind Carbon Copy Address
                 blindCarbonCopyAddress =
+            }
+            senderNotification {
+                # cat=plugin.sessionplaner/135_SPSUGGESTSENDERMAIL/enable; type=boolean; label=Enable
+                enable = 0
+                # cat=plugin.sessionplaner/135_SPSUGGESTSENDERMAIL/subject; type=string; label=Subject
+                subject = Thank you for your suggestion
+                # cat=plugin.sessionplaner/135_SPSUGGESTSENDERMAIL/senderAddress; type=string; label=Sender Address
+                senderAddress =
+                # cat=plugin.sessionplaner/135_SPSUGGESTSENDERMAIL/senderName; type=string; label=Sender Name
+                senderName =
             }
             confirmation {
                 # cat=plugin.sessionplaner/140_SPSUGGESTCONFIRMATION/message; type=string; label=Confirmation Message

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -78,6 +78,15 @@ plugin.tx_sessionplaner {
                         max = 255
                     }
                 }
+                subtitle {
+                    enable = 0
+                    label = LLL:EXT:sessionplaner/Resources/Private/Language/locallang.xlf:form.subtitle
+                    description = LLL:EXT:sessionplaner/Resources/Private/Language/locallang.xlf:form.subtitle.description
+                    validation {
+                        min = 0
+                        max = 255
+                    }
+                }
                 description {
                     label = LLL:EXT:sessionplaner/Resources/Private/Language/locallang.xlf:form.description
                     description = LLL:EXT:sessionplaner/Resources/Private/Language/locallang.xlf:form.description.description

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -87,6 +87,15 @@ plugin.tx_sessionplaner {
                         max = 255
                     }
                 }
+                tag_suggestion {
+                    enable = 0
+                    label = LLL:EXT:sessionplaner/Resources/Private/Language/locallang.xlf:form.tag_suggestion
+                    description = LLL:EXT:sessionplaner/Resources/Private/Language/locallang.xlf:form.tag_suggestion.description
+                    validation {
+                        min = 0
+                        max = 255
+                    }
+                }
                 description {
                     label = LLL:EXT:sessionplaner/Resources/Private/Language/locallang.xlf:form.description
                     description = LLL:EXT:sessionplaner/Resources/Private/Language/locallang.xlf:form.description.description

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -73,6 +73,10 @@ plugin.tx_sessionplaner {
                 title {
                     label = LLL:EXT:sessionplaner/Resources/Private/Language/locallang.xlf:form.title
                     description = LLL:EXT:sessionplaner/Resources/Private/Language/locallang.xlf:form.title.description
+                    validation {
+                        min = 1
+                        max = 255
+                    }
                 }
                 description {
                     label = LLL:EXT:sessionplaner/Resources/Private/Language/locallang.xlf:form.description

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -127,6 +127,12 @@ plugin.tx_sessionplaner {
                 carbonCopyAddress = {$plugin.tx_sessionplaner.settings.suggest.notification.carbonCopyAddress}
                 blindCarbonCopyAddress = {$plugin.tx_sessionplaner.settings.suggest.notification.blindCarbonCopyAddress}
             }
+            senderNotification {
+                enable = {$plugin.tx_sessionplaner.settings.suggest.senderNotification.enable}
+                subject = {$plugin.tx_sessionplaner.settings.suggest.senderNotification.subject}
+                senderAddress = {$plugin.tx_sessionplaner.settings.suggest.senderNotification.senderAddress}
+                senderName = {$plugin.tx_sessionplaner.settings.suggest.senderNotification.senderName}
+            }
             confirmation {
                 message = {$plugin.tx_sessionplaner.settings.suggest.confirmation.message}
                 pageUid = {$plugin.tx_sessionplaner.settings.suggest.confirmation.pageUid}

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -221,6 +221,12 @@
       <trans-unit id="form.description.description">
         <source>A description of your submission</source>
       </trans-unit>
+      <trans-unit id="form.tag_suggestion">
+        <source>Tag Suggestion</source>
+      </trans-unit>
+      <trans-unit id="form.tag_suggestion.description">
+        <source>A descriptive tag you would add to your submission</source>
+      </trans-unit>
       <trans-unit id="form.type">
         <source>Type</source>
       </trans-unit>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -209,6 +209,12 @@
       <trans-unit id="form.title.description">
         <source>A descriptive title for your submission</source>
       </trans-unit>
+      <trans-unit id="form.subtitle">
+        <source>Subtitle</source>
+      </trans-unit>
+      <trans-unit id="form.subtitle.description">
+        <source>A descriptive subtitle for your submission</source>
+      </trans-unit>
       <trans-unit id="form.description">
         <source>Description</source>
       </trans-unit>

--- a/Resources/Private/Language/locallang_tca.xlf
+++ b/Resources/Private/Language/locallang_tca.xlf
@@ -135,6 +135,9 @@
       <trans-unit id="tx_sessionplaner_domain_model_session-topic" xml:space="preserve">
         <source>Topic</source>
       </trans-unit>
+      <trans-unit id="tx_sessionplaner_domain_model_session-topic_addition" xml:space="preserve">
+        <source>Topic Addition</source>
+      </trans-unit>
       <trans-unit id="tx_sessionplaner_domain_model_session-path_segment" xml:space="preserve">
         <source>Path Segment</source>
       </trans-unit>

--- a/Resources/Private/Language/locallang_tca.xlf
+++ b/Resources/Private/Language/locallang_tca.xlf
@@ -132,6 +132,9 @@
       <trans-unit id="tx_sessionplaner_domain_model_session-donotlink" xml:space="preserve">
         <source>Do not link</source>
       </trans-unit>
+      <trans-unit id="tx_sessionplaner_domain_model_session-tag_suggestion" xml:space="preserve">
+        <source>Tag Suggestion</source>
+      </trans-unit>
       <trans-unit id="tx_sessionplaner_domain_model_session-topic" xml:space="preserve">
         <source>Topic</source>
       </trans-unit>

--- a/Resources/Private/Templates/Email/EmailToSender.html
+++ b/Resources/Private/Templates/Email/EmailToSender.html
@@ -1,0 +1,49 @@
+<f:layout name="SystemEmail" />
+<f:section name="Title">{title}</f:section>
+<f:section name="Main">
+    <f:if condition="{message}">
+        <p>{message}</p>
+        <hr>
+    </f:if>
+    <table>
+        <formvh:renderAllFormValues renderable="{form.formDefinition}" as="formValue">
+            <tr>
+                <f:if condition="{formValue.isSection}">
+                    <f:then>
+                        <td colspan="2"><b>{formvh:translateElementProperty(element: formValue.element, property: 'label')}</b></td>
+                    </f:then>
+                    <f:else>
+                        <td valign="top" align="left">{formvh:translateElementProperty(element: formValue.element, property: 'label')}</td>
+                        <td valign="top" align="left">
+                            <f:if condition="{formValue.value}">
+                                <f:then>
+                                    <f:if condition="{formValue.isMultiValue}">
+                                        <f:then>
+                                            <table cellspacing="0" border="0">
+                                                <f:for each="{formValue.processedValue}" as="value">
+                                                    <tr>
+                                                        <td>{value}</td>
+                                                    </tr>
+                                                </f:for>
+                                            </table>
+                                        </f:then>
+                                        <f:else>
+                                            <table cellspacing="0" border="0">
+                                                <tr>
+                                                    <td><f:format.nl2br>{formValue.processedValue}</f:format.nl2br></td>
+                                                </tr>
+                                            </table>
+                                        </f:else>
+                                    </f:if>
+                                </f:then>
+                                <f:else>
+                                    -
+                                </f:else>
+                            </f:if>
+                        </td>
+                    </f:else>
+                </f:if>
+            </tr>
+        </formvh:renderAllFormValues>
+    </table>
+</f:section>

--- a/Resources/Private/Templates/Email/EmailToSender.txt
+++ b/Resources/Private/Templates/Email/EmailToSender.txt
@@ -1,0 +1,18 @@
+<f:layout name="SystemEmail" />
+<f:section name="Title">{title}</f:section>
+<f:section name="Main">
+<f:if condition="{message}">{message}</f:if>
+
+<formvh:renderAllFormValues renderable="{form.formDefinition}" as="formValue"><f:spaceless>
+    <f:if condition="{formValue.isMultiValue}">
+        <f:then>
+            <f:if condition="{formValue.isSection}"><f:then>*** <formvh:translateElementProperty element="{formValue.element}" property="label" /> ***</f:then><f:else><formvh:translateElementProperty element="{formValue.element}" property="label" />: <f:for each="{formValue.processedValue}" as="singleValue">- {singleValue}
+            </f:for></f:else></f:if>
+        </f:then>
+        <f:else>
+            <f:if condition="{formValue.isSection}"><f:then>*** <formvh:translateElementProperty element="{formValue.element}" property="label" /> ***</f:then><f:else><formvh:translateElementProperty element="{formValue.element}" property="label" />: <f:if condition="{formValue.processedValue}"><f:then>{formValue.processedValue -> f:format.raw()}</f:then><f:else>-</f:else></f:if></f:else></f:if>
+        </f:else>
+    </f:if>
+</f:spaceless>
+</formvh:renderAllFormValues>
+</f:section>

--- a/Resources/Private/Templates/Session/Show.html
+++ b/Resources/Private/Templates/Session/Show.html
@@ -22,6 +22,11 @@
                 <div class="sessionplaner-sessiondetail-title">
                     <h1>{session.topic}</h1>
                 </div>
+                <f:if condition="{session.topicAddition}">
+                    <div class="sessionplaner-sessiondetail-subtitle">
+                        <h2>{session.topicAddition}</h2>
+                    </div>
+                </f:if>
                 <div class="sessionplaner-sessiondetail-main">
                     <f:if condition="{session.description}">
                     <div class="sessionplaner-sessiondetail-description">

--- a/Resources/Public/Stylesheets/frontend.css
+++ b/Resources/Public/Stylesheets/frontend.css
@@ -54,7 +54,7 @@
   border-radius: var(--session-tag-border-radius);
 }
 
-.sessionplaner-tag-title {
+.sessionplaner-tag-title, .sessionplaner-tag-subtitle {
   --session-tag-title-decoration-color: inherit;
   text-decoration-line: underline;
   text-decoration-thickness: 5px;

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -45,6 +45,7 @@ CREATE TABLE tx_sessionplaner_domain_model_slot
 CREATE TABLE tx_sessionplaner_domain_model_session
 (
     topic           varchar (255) DEFAULT '' NOT NULL,
+		topic_addition  varchar (255) DEFAULT '' NOT NULL,
     path_segment    varchar(2048),
     speaker         varchar(255) DEFAULT '' NOT NULL,
     twitter         varchar(255) DEFAULT '' NOT NULL,

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -58,6 +58,7 @@ CREATE TABLE tx_sessionplaner_domain_model_session
     requesttype     int(11) unsigned DEFAULT '0' NOT NULL,
     norecording     tinyint(4) unsigned DEFAULT '0' NOT NULL,
     description     text,
+		tag_suggestion  varchar (255) DEFAULT '' NOT NULL,
 
     # references
     speakers        int(11) unsigned DEFAULT '0' NOT NULL,

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -45,7 +45,7 @@ CREATE TABLE tx_sessionplaner_domain_model_slot
 CREATE TABLE tx_sessionplaner_domain_model_session
 (
     topic           varchar (255) DEFAULT '' NOT NULL,
-		topic_addition  varchar (255) DEFAULT '' NOT NULL,
+    topic_addition  varchar (255) DEFAULT '' NOT NULL,
     path_segment    varchar(2048),
     speaker         varchar(255) DEFAULT '' NOT NULL,
     twitter         varchar(255) DEFAULT '' NOT NULL,
@@ -58,7 +58,7 @@ CREATE TABLE tx_sessionplaner_domain_model_session
     requesttype     int(11) unsigned DEFAULT '0' NOT NULL,
     norecording     tinyint(4) unsigned DEFAULT '0' NOT NULL,
     description     text,
-		tag_suggestion  varchar (255) DEFAULT '' NOT NULL,
+    tag_suggestion  varchar (255) DEFAULT '' NOT NULL,
 
     # references
     speakers        int(11) unsigned DEFAULT '0' NOT NULL,


### PR DESCRIPTION
This PR introduces two new fields `subtitle` & `tag_suggestion`, adds the possibility to send confirmation mails to the sender on session suggestions and adds string length validators to `title` and the newly added fields.
