### PR TITLE
[BUGFIX] Exclude detail_page from language overlay

### DIFF
--- a/Configuration/TCA/tx_sessionplaner_domain_model_speaker.php
+++ b/Configuration/TCA/tx_sessionplaner_domain_model_speaker.php
@@ -157,6 +157,7 @@ return [
         'detail_page' => [
             'exclude' => false,
             'label' => $languageFile . 'tx_sessionplaner_domain_model_speaker-detail_page',
+            'l10n_mode' => 'exclude',
             'config' => [
                 'type' => 'group',
                 'allowed' => 'pages',


### PR DESCRIPTION
detail_page must not be overridden per language translation. When a translated speaker record carries a stale or wrong detail_page pointing to a page in a different site, f:link.page generates a cross-site absolute URL with the wrong domain instead of falling back to the speakerSinglePid plugin setting.